### PR TITLE
IPA finder: Support lower case nucleotides

### DIFF
--- a/src/IPA_finder.pl
+++ b/src/IPA_finder.pl
@@ -36,7 +36,7 @@ if (defined($help) || ! $fasta_file){
 my %seq = %{read_fasta ($fasta_file)};
 
 foreach my $chr (keys %seq){
-    my $seq = $seq{$chr};
+    my $seq = uc($seq{$chr});
     my $splus=$seq;
     $splus=~tr/ATGCN/10000/;
     my @plus  = @{find_matches ($splus,0)};


### PR DESCRIPTION
GENCODE use `N` for masking in their genome FASTAs, but other sources use lower case letters instead. This stops the internal priming finder script for custom genomes from failing given such genome FASTAs.